### PR TITLE
Fix web client in cases of long installed modules list

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -228,15 +228,15 @@ class ir_cron(models.Model):
 
                     locked_job = lock_cr.fetchone()
                     if not locked_job:
-                        _logger.debug("Job `%s` already executed by another process/thread. skipping it", job['cron_name'])
+                        _logger.warning("Job `%s` already executed by another process/thread. skipping it", job['cron_name'])
                         continue
                     # Got the lock on the job row, run its code
-                    _logger.info('Starting job `%s`.', job['cron_name'])
+                    _logger.warning('Starting job `%s`.', job['cron_name'])
                     job_cr = db.cursor()
                     try:
                         registry = odoo.registry(db_name)
                         registry[cls._name]._process_job(job_cr, job, lock_cr)
-                        _logger.info('Job `%s` done.', job['cron_name'])
+                        _logger.warning('Job `%s` done.', job['cron_name'])
                     except Exception:
                         _logger.exception('Unexpected exception while processing cron job %r', job)
                     finally:
@@ -245,7 +245,7 @@ class ir_cron(models.Model):
                 except psycopg2.OperationalError as e:
                     if e.pgcode == '55P03':
                         # Class 55: Object not in prerequisite state; 55P03: lock_not_available
-                        _logger.debug('Another process/thread is already busy executing job `%s`, skipping it.', job['cron_name'])
+                        _logger.warning('Another process/thread is already busy executing job `%s`, skipping it.', job['cron_name'])
                         continue
                     else:
                         # Unexpected OperationalError


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
414 when the http request hits the CDN - Cloudflare

Current behavior before PR:
http response 414 request too large when over 1000 chars, about 561 modules 

```sql
select name, state, count(*) over (partition by 1) cnt
, length(name) l , sum(length(name)) over (partition by 1) total_len
from ir_module_module
where state='installed'
order by  length(name) desc;
```

Desired behavior after PR is merged:
the web client operates without 414 even over the 1000 length of sum module names

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
