### PR TITLE
Fixing DeprecationWarning: distutils Version classes are deprecated. …

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -21,7 +21,8 @@ import json
 
 from lxml import etree
 from contextlib import closing
-from distutils.version import LooseVersion
+from packaging import version
+from reportlab.graphics.barcode import createBarcodeDrawing
 from PyPDF2 import PdfFileWriter, PdfFileReader, utils
 from collections import OrderedDict
 from collections.abc import Iterable
@@ -69,13 +70,13 @@ else:
     out, err = process.communicate()
     match = re.search(b'([0-9.]+)', out)
     if match:
-        version = match.group(0).decode('ascii')
-        if LooseVersion(version) < LooseVersion('0.12.0'):
+        current_version = match.group(0).decode('ascii')
+        if version.parse(current_version) < version.parse("0.12.0"):
             _logger.info('Upgrade Wkhtmltopdf to (at least) 0.12.0')
             wkhtmltopdf_state = 'upgrade'
         else:
             wkhtmltopdf_state = 'ok'
-        if LooseVersion(version) >= LooseVersion('0.12.2'):
+        if version.parse(current_version) >= version.parse("0.12.2"):
             wkhtmltopdf_dpi_zoom_ratio = True
 
         if config['workers'] == 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ MarkupSafe==1.1.0
 num2words==0.5.6
 ofxparse==0.19; python_version <= '3.9'
 ofxparse==0.21; python_version > '3.9'  # (Jammy) ABC removed from collections in 3.10 but still used in ofxparse < 0.21
+packaging==21.3
 passlib==1.7.1
 Pillow==5.4.1 ; python_version <= '3.7' and sys_platform != 'win32'
 Pillow==6.1.0 ; python_version <= '3.7' and sys_platform == 'win32'


### PR DESCRIPTION
…Use packaging.version instead.

As reported in this issue, https://github.com/odoo/odoo/issues/83878, when starting the server also in v15 there is an annoying warning as follows

py.warnings odoo/addons/base/models/ir_actions_report.py:73: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
File "./odoo-bin", line 8, in <module>
    odoo.cli.main()
  File "odoo/cli/command.py", line 61, in main
    o.run(args)
  File "odoo/cli/server.py", line 176, in run
    main(args)
  File "odoo/cli/server.py", line 170, in main
    rc = odoo.service.server.start(preload=preload, stop=stop)
  File "odoo/service/server.py", line 1286, in start
    load_server_wide_modules()
  File "odoo/service/server.py", line 1196, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "odoo/modules/module.py", line 396, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "odoo/addons/base/__init__.py", line 5, in <module>
    from . import models
  File "odoo/addons/base/models/__init__.py", line 13, in <module>
    from . import ir_actions_report
  File "odoo/addons/base/models/ir_actions_report.py", line 73, in <module>
    if LooseVersion(version) >= LooseVersion('0.12.2'):

This commit fixes that.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
