### PR TITLE
[FIX] stock: Reformulation of the quantity constraint by the quants

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -250,8 +250,15 @@ class StockQuant(models.Model):
     @api.constrains('quantity')
     def check_quantity(self):
         for quant in self:
+            quants = self.env["stock.quant"].search(
+                [
+                    ("product_id", "=", quant.product_id.id),
+                    ("location_id", "=", quant.location_id.id),
+                    ("lot_id", "=", quant.lot_id.id),
+                ]
+            )
             if quant.location_id.usage != 'inventory' and quant.lot_id and quant.product_id.tracking == 'serial' \
-                    and float_compare(abs(quant.quantity), 1, precision_rounding=quant.product_uom_id.rounding) > 0:
+                    and float_compare(abs(sum(quants.mapped("quantity"))), 1, precision_rounding=quant.product_uom_id.rounding) > 0:
                 raise ValidationError(_('The serial number has already been assigned: \n Product: %s, Serial Number: %s') % (quant.product_id.display_name, quant.lot_id.name))
 
     @api.constrains('location_id')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Situation 1: A quant of a serial product must be able to have more than one unit as long as the sum of all the quants of that serial product and at that location is not greater than 1. That is, a product must be able to return more than once.

Situation 2: At the same time, a serial product should not have more than one unit in a location that is not of the 'Inventory Loss' type.

To ensure that you do not have a duplicate serial product in a location it is necessary that the absolute value of the sum of the quantities of that product in that location is less than 1. This is mainly thought for products that are stored in Units. If a product is stored in 'kilograms' (grams), you could have more than one quant in 'WH/ Stock' if the sum of the quantities is less than 1.


Current behavior before PR:

Situation 1: You can't return a serial product more than once if it went out with different packages because it would end up with a quant in 'WH/Customers' location of -2 units. Check how to reproduce steps at the end of the description.

https://github.com/odoo/odoo/assets/90243017/e3422890-c3a5-48f2-b023-80fc4e5d9cdc

Situation 2: You are allowed to have more than one unit of a serial product in 'Stock' location. You can arrive in this situation if packages are different.

https://github.com/odoo/odoo/assets/90243017/bc2f6935-0a92-4e6f-9688-9b25d8846e4c


Desired behavior after PR is merged:

Situation 1: You can return a serial product more than once if it went out with different packages. A quant can end up with -2 units in 'WH/Customers' location.

https://github.com/odoo/odoo/assets/90243017/fdac4f3e-ce1f-4071-b27d-e53b513e9094

Situation 2: You are not allowed to have more than one unit of a serial product in 'Stock' location. 

https://github.com/odoo/odoo/assets/90243017/04807841-4d59-488e-8d54-003e09dddac8


How to reproduce the issue:

Situation 1:
1. Create a serialized product and add 1 unit in stock
2. Deliver the product to a customer, with a package
3. Return the product to stock, and create an incoming shipment. Complete it. 
4. Deliver the product again to the customer, this time creating another package before shipping.
5. Click to return the product in the delivery order, and create an incoming shipment. At this time the error occurs.

Situate 2:
1. Create a stock quant for a serialized product with a package in 'WH/Stock'.
2. Create another stock quant for the same serialized product with a different package in 'WH/Stock'. At this time the error should occur.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
