### PR TITLE
[FIX] mrp: cancel finished moves when an MO does not have components

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1361,6 +1361,7 @@ class MrpProduction(models.Model):
         orders in exception """
         self.workorder_ids.filtered(lambda x: x.state not in ['done', 'cancel']).action_cancel()
         if not self.move_raw_ids:
+            self.move_finished_ids.filtered(lambda x: x.state not in ('done', 'cancel'))._action_cancel()
             self.state = 'cancel'
             return True
         self._action_cancel()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
